### PR TITLE
Added: Custom Constructor

### DIFF
--- a/code-generator.js
+++ b/code-generator.js
@@ -414,8 +414,8 @@ class JavaCodeGenerator {
       }
       if (constructorOperation) {
         // Generate constructor using parameters from the UML operation
-        var params = constructorOperation.params.map(param => `${param.type} ${param.name}`).join(', ')
-        terms.push(`${elem.name}(${params})`)
+        var params = constructorOperation.params.map(param => param.type + " " + param.name).join(', ')
+        terms.push(elem.name + '(' + params + ')')
       } else {
         terms.push(elem.name + '()')
       }

--- a/code-generator.js
+++ b/code-generator.js
@@ -398,27 +398,17 @@ class JavaCodeGenerator {
    * @param {type.Model} elem
    * @param {Object} options
    */
-  writeConstructor (codeWriter, elem, options, imports, curPackage) {
+    writeConstructor (codeWriter, elem, options, imports, curPackage) {
     if (elem.name.length > 0) {
       var terms = []
-
-      // Check if there's an operation with the same name as the class (custom constructor)
-      var constructorOperation = elem.operations.find(op => op.name === elem.name)
-      
       // Doc
-      this.writeDoc(codeWriter, constructorOperation ? 'Custom constructor' : 'Default constructor', options, imports, curPackage)
+      this.writeDoc(codeWriter, 'Default constructor', options, imports, curPackage)
       // Visibility
       var visibility = this.getVisibility(elem)
       if (visibility) {
         terms.push(visibility)
       }
-      if (constructorOperation) {
-        // Generate constructor using parameters from the UML operation
-        var params = constructorOperation.params.map(param => param.type + " " + param.name).join(', ')
-        terms.push(elem.name + '(' + params + ')')
-      } else {
-        terms.push(elem.name + '()')
-      }
+      terms.push(elem.name + '()')
       codeWriter.writeLine(terms.join(' ') + ' {')
       codeWriter.writeLine('}')
     }
@@ -471,6 +461,7 @@ class JavaCodeGenerator {
       var terms = []
       var params = elem.getNonReturnParameters()
       var returnParam = elem.getReturnParameter()
+      var isConstructor = (elem.name === owner.name)
 
       // doc
       var doc = elem.documentation.trim()
@@ -500,14 +491,10 @@ class JavaCodeGenerator {
       }
 
       // type
-      if (returnParam) {
+      if (returnParam && !isConstructor) {
         terms.push(this.getType(returnParam, imports, curPackage))
-      } else {
-        if (elem.name === owner.name) {
-          //constructor has no return
-        }else{
-          terms.push('void') 
-        }
+      } else if (!isConstructor) {
+        terms.push('void') 
       }
 
       // name + parameters
@@ -538,7 +525,7 @@ class JavaCodeGenerator {
         }
         
         // return statement
-        if (returnParam) {
+        if (returnParam && !isConstructor) {
           var returnType = this.getType(returnParam, imports, curPackage)
           if (returnType === 'boolean') {
             codeWriter.writeLine('return false;')

--- a/code-generator.js
+++ b/code-generator.js
@@ -401,14 +401,24 @@ class JavaCodeGenerator {
   writeConstructor (codeWriter, elem, options, imports, curPackage) {
     if (elem.name.length > 0) {
       var terms = []
+
+      // Check if there's an operation with the same name as the class (custom constructor)
+      var constructorOperation = elem.operations.find(op => op.name === elem.name)
+      
       // Doc
-      this.writeDoc(codeWriter, 'Default constructor', options, imports, curPackage)
+      this.writeDoc(codeWriter, constructorOperation ? 'Custom constructor' : 'Default constructor', options, imports, curPackage)
       // Visibility
       var visibility = this.getVisibility(elem)
       if (visibility) {
         terms.push(visibility)
       }
-      terms.push(elem.name + '()')
+      if (constructorOperation) {
+        // Generate constructor using parameters from the UML operation
+        var params = constructorOperation.params.map(param => `${param.type} ${param.name}`).join(', ')
+        terms.push(`${elem.name}(${params})`)
+      } else {
+        terms.push(elem.name + '()')
+      }
       codeWriter.writeLine(terms.join(' ') + ' {')
       codeWriter.writeLine('}')
     }


### PR DESCRIPTION
When a UML class has the same name as a UML operation it owns. 

Example output:
`	/**
	 * Default constructor
	 */
	public Person() {
	}

	/**
	 * 
	 */
	private String name;

	/**
	 * @param name
	 */
	public Person(String name) {
		// TODO implement here
	}`

Areas of future improvement: If it's a constructor, it could be good to also have documentation reflect that since right now it will only show the params in the docs. 